### PR TITLE
Fix sass typo

### DIFF
--- a/web/views/index.jade
+++ b/web/views/index.jade
@@ -62,7 +62,7 @@ block content
         $picnic-primary: #faa;
 
         // Add picnic to your codebase
-        @include 'bower/picnic/src/picnic';
+        @import 'bower/picnic/src/picnic';
 
         // Create a new element
         .call-to-action {


### PR DESCRIPTION
Sass module are included with `@import` statements, not `@include`.