### PR TITLE
Fix grid sizing when there's empty divs

### DIFF
--- a/src/plugins/grid/_plugin.scss
+++ b/src/plugins/grid/_plugin.scss
@@ -68,7 +68,6 @@
     vertical-align: top;
     margin: 0;
     float: none;
-    width: 100%;
   }
 
   // Don't display this one
@@ -112,7 +111,3 @@
     width: 80%;
   }
 }
-
-
-
-


### PR DESCRIPTION
The `.half`, `.third`, `.fifth`, etc classes were not sizing correctly (see test page) due to the empty divs in the row having `width: 100%`. Removing that property from the empty divs allows everything to size correctly.