### PR TITLE
Remove excess specificity on the input element

### DIFF
--- a/src/plugins/normalize/_plugin.scss
+++ b/src/plugins/normalize/_plugin.scss
@@ -298,7 +298,7 @@ input[type="submit"] {
  */
 
 button[disabled],
-html input[disabled] {
+input[disabled] {
   cursor: default;
 }
 


### PR DESCRIPTION
The 'html' element requires extra friction when overriding default styles. 
Is it required for any reason?
