### PR TITLE
Allow any node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.3.1",
   "description": "A lighweight CSS library with nice defaults and many plugins to kickstart your projects",
   "engines": {
-    "node": "4.0.0"
+    "node": "*"
   },
   "scripts": {
     "setremotes": "git remote set-url --add --push origin git@github.com:picnicss/picnic.git && git remote set-url --add --push origin git@github.com:picnicss/picnicss.github.io.git"


### PR DESCRIPTION
Since npm is sloppy, it allows installing packages that say to only use node 4.0.0, even if you're using a different version of node.

[Yarn](https://yarnpkg.com/) is not so sloppy.

I want to switch to yarn, but `picnic` is causing problems.

I don't know if the version of node actually matters for `picnic`. If it does, then a range of node versions [can be specified](https://docs.npmjs.com/files/package.json#engines). I doubt it matters, though!